### PR TITLE
Handle schemas with custom root query and mutation type names

### DIFF
--- a/lib/tester.js
+++ b/lib/tester.js
@@ -4,6 +4,7 @@ const mocker = require('easygraphql-mock')
 const schemaParser = require('easygraphql-parser')
 const assert = require('assert')
 const queryParser = require('./queryParser')
+const { queryField, mutationField } = require('../utils/schemaDefinition')
 const { argumentsValidator, inputValidator, validator } = require('../utils/validator')
 
 class Tester {
@@ -26,20 +27,22 @@ class Tester {
     let mock
     switch (operationType.toLowerCase()) {
       case 'query':
+        const Query = queryField(this.schema)
         // Search the query on the Schema Code parsed into an object
-        const querySchema = this.schema.Query.fields.filter(el => el.name === name)
+        const querySchema = this.schema[Query].fields.filter(el => el.name === name)
         // Create a mock and validate the query on the schema
-        mock = validator(parsedQuery, this.mockedSchema.Query[name], this.schema, 'Query')
+        mock = validator(parsedQuery, this.mockedSchema[Query][name], this.schema, 'Query')
         // Check if the query receives args and check if the required ones are passed
         argumentsValidator(parsedQuery.arguments, querySchema[0].arguments, name, queryVariables)
         // Return the mock of the selected fields
         return { [queryName]: mock }
 
       case 'mutation':
+        const Mutation = mutationField(this.schema)
         // Search the mutation on the Schema Code parsed into an object
-        const mutationSchema = this.schema.Mutation.fields.filter(el => el.name === name)
+        const mutationSchema = this.schema[Mutation].fields.filter(el => el.name === name)
         // Create a mock and validate the mutation on the schema
-        mock = validator(parsedQuery, this.mockedSchema.Mutation[name], this.schema, 'Mutation')
+        mock = validator(parsedQuery, this.mockedSchema[Mutation][name], this.schema, 'Mutation')
         // The mutation must receive a input, so must check if it receives the correct one
         inputValidator(parsedQuery.variables, mutationSchema[0].arguments, this.schema, name)
         // Return the mock of the selected fields

--- a/test/query.js
+++ b/test/query.js
@@ -9,6 +9,7 @@ const EasyGraphQLTester = require('../lib')
 
 const userSchema = fs.readFileSync(path.join(__dirname, 'schema', 'user.gql'), 'utf8')
 const familySchema = fs.readFileSync(path.join(__dirname, 'schema', 'family.gql'), 'utf8')
+const customRootTypeNamesSchema = fs.readFileSync(path.join(__dirname, 'schema', 'customRootTypeNames.gql'), 'utf8')
 
 describe('Query', () => {
   let tester
@@ -616,6 +617,44 @@ describe('Query', () => {
       const { aliasTest } = tester.mock(query)
       expect(aliasTest).to.exist
       expect(aliasTest.email).to.be.a('string')
+    })
+  })
+
+  describe('Should support custom names for root types', () => {
+    let tester
+
+    before(() => {
+      tester = new EasyGraphQLTester(customRootTypeNamesSchema)
+    })
+
+    it('Should support a custom name for the root query type', () => {
+      const query = `
+        query getPosts {
+          posts {
+            content
+          }
+        }
+      `
+
+      const { posts } = tester.mock(query)
+      expect(posts).to.exist
+      expect(posts).to.be.a('array')
+      expect(posts.length).to.be.gt(0)
+      expect(posts[0].content).to.be.a('string')
+    })
+
+    it('Should support a custom name for the root mutation type', () => {
+      const mutation = `
+        mutation addPost($content: String!) {
+          appendPost(content: $content) {
+            content
+          }
+        }
+      `
+
+      const { appendPost } = tester.mock(mutation, { content: 'Hello, world!' })
+      expect(appendPost).to.exist
+      expect(appendPost.content).to.be.a('string')
     })
   })
 })

--- a/test/schema/customRootTypeNames.gql
+++ b/test/schema/customRootTypeNames.gql
@@ -1,0 +1,16 @@
+schema {
+  query: RootQuery
+  mutation: RootMutation
+}
+
+type Post {
+  content: String!
+}
+
+type RootQuery {
+  posts: [Post!]!
+}
+
+type RootMutation {
+  appendPost(post: Post!): Post!
+}

--- a/utils/schemaDefinition.js
+++ b/utils/schemaDefinition.js
@@ -3,6 +3,7 @@
 /**
  * Returns the name of the root query type defined in a schema, or "Query" if
  * the schema does not explicitly specify a root query type.
+ * @param schema - The GraphQL schema to read field names from.
  * @returns {string}
  */
 function queryField (schema) {
@@ -12,6 +13,7 @@ function queryField (schema) {
 /**
  * Returns the name of the root mutation type defined in a schema, or "Mutation"
  * if the schema does not explicitly specify a root mutation type.
+ * @param schema - The GraphQL schema to read field names from.
  * @returns {string}
  */
 function mutationField (schema) {

--- a/utils/schemaDefinition.js
+++ b/utils/schemaDefinition.js
@@ -1,0 +1,21 @@
+'use strict'
+
+/**
+ * Returns the name of the root query type defined in a schema, or "Query" if
+ * the schema does not explicitly specify a root query type.
+ * @returns {string}
+ */
+function queryField (schema) {
+  return schema.schemaDefinition ? schema.schemaDefinition.query.field : 'Query'
+}
+
+/**
+ * Returns the name of the root mutation type defined in a schema, or "Mutation"
+ * if the schema does not explicitly specify a root mutation type.
+ * @returns {string}
+ */
+function mutationField (schema) {
+  return schema.schemaDefinition ? schema.schemaDefinition.mutation.field : 'Mutation'
+}
+
+module.exports = { queryField, mutationField }

--- a/utils/validator.js
+++ b/utils/validator.js
@@ -2,6 +2,7 @@
 
 const isObject = require('lodash.isobject')
 const isEmpty = require('lodash.isempty')
+const { queryField, mutationField } = require('./schemaDefinition')
 
 /**
  * Find if the required arguments are passed
@@ -180,9 +181,9 @@ function validator (query, mock, schema, type) {
 
   let schemaType
   if (type === 'Query') {
-    schemaType = schema.Query.fields.filter(el => el.name === query.name)[0]
+    schemaType = schema[queryField(schema)].fields.filter(el => el.name === query.name)[0]
   } else {
-    schemaType = schema.Mutation.fields.filter(el => el.name === query.name)[0]
+    schemaType = schema[mutationField(schema)].fields.filter(el => el.name === query.name)[0]
   }
   // If the mock is array, it will loop each value, so the query can access
   // each value requested on the Query/Mutation


### PR DESCRIPTION
I am working with a schema where the root query and mutation types are named `RootQueryType` and `RootMutationType`. It is necessary to read `schema.schemaDefinition` to infer that information.

I can work around the issue by doing a search and replace on those type names before feeding the schema to EasyGraphQL. But it would be nice to handle such cases automatically.