### PR TITLE
Fix for missing falsy values in nested positions

### DIFF
--- a/test/query.js
+++ b/test/query.js
@@ -488,6 +488,24 @@ describe('Query', () => {
       expect(getUsers[0].username).to.be.a('string')
       expect(getUsers[0].fullName).to.be.a('string')
     })
+
+    it('Should return falsy field values in nested positions', () => {
+      const query = `
+        {
+          getMe {
+            familyInfo {
+              id
+              isLocal
+            }
+          }
+        }
+      `
+
+      const { getMe } = tester.mock(query)
+      for (const familyInfo of getMe.familyInfo) {
+        expect(familyInfo.isLocal).to.be.a('boolean')
+      }
+    })
   })
 
   describe('Should support unions', () => {

--- a/utils/validator.js
+++ b/utils/validator.js
@@ -267,7 +267,7 @@ function mockBuilder (field, mock, name) {
       const mockResult = {}
       field.fields.forEach(element => {
         const result = mockBuilder(element, el, name)
-        if (result) {
+        if (typeof result !== 'undefined') {
           mockResult[element.name] = result
         }
       })
@@ -282,7 +282,7 @@ function mockBuilder (field, mock, name) {
     field.fields.forEach(element => {
       const result = mockBuilder(element, mock[field.name], name)
 
-      if (result) {
+      if (typeof result !== 'undefined') {
         mockResult[element.name] = result
       }
     })


### PR DESCRIPTION
I added a test to demonstrate the issue, which will fail about half the time without the fix.